### PR TITLE
remove direct openmm import

### DIFF
--- a/wrappers/python/DLExtForce.i
+++ b/wrappers/python/DLExtForce.i
@@ -9,7 +9,7 @@ except:
     openmm = import_module("simtk.openmm")
 %}
 
-%import(module = "openmm") "OpenMMForce.i"
+%import "OpenMMForce.i"
 %include "std_string.i"
 
 %{


### PR DESCRIPTION
At the moment, I cannot import openmm-dlext properly with openmm version 7.5.
The `import openmm` statement fails, since you import `simtk`.
Modifying the line, I highlight here, fixes the import, but I can't run openmm anywhere right now, so. not sure if that works.

Locally on my machine i get a segfault, might be related, might not be.