### PR TITLE
Preparation for trunk merge queue

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1,0 +1,9 @@
+name: Merge Queue
+on: workflow_dispatch
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  docker:
+    uses: ./.github/workflows/docker.yml


### PR DESCRIPTION
At the moment trunk requires a single workflow file for the automatic merge queue.

This is a work around to combine our multiple workflow files.

I want to test trunk merge queue.

Later this month trunk will have a dedicated setup for the trunk workflow files.